### PR TITLE
Add utils property and update list expressions

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -40,6 +40,11 @@ require_once($CFG->dirroot . '/plagiarism/originality/locallib.php');
 class plagiarism_plugin_originality extends plagiarism_plugin {
 
     /**
+     * @var plagiarism_plugin_originality_utils
+     */
+    public $utils;
+
+    /**
      * Constructor function for the class.
      * Initializes the plagiarism_plugin_originality_utils object for accessing utility functions.
      *
@@ -633,7 +638,7 @@ class plagiarism_plugin_originality extends plagiarism_plugin {
 
         if (isset($eventdata['objecttable']) && $eventdata['objecttable'] == 'assign_submission') {
             $userid = $eventdata['userid'];
-            list ($course, $cm) = get_course_and_cm_from_cmid($eventdata['contextinstanceid'], 'assign');
+            [$course, $cm] = get_course_and_cm_from_cmid($eventdata['contextinstanceid'], 'assign');
             $context = context_module::instance($cm->id);
             $assign = new assign($context, $cm, $course);
             $cmod = $assign->get_instance();
@@ -717,7 +722,7 @@ class plagiarism_plugin_originality extends plagiarism_plugin {
         if ($eventdata['contextinstanceid'] && $eventdata['contextinstanceid'] != 1) {
             require_once($CFG->dirroot . '/mod/assign/locallib.php');
 
-            list ($course, $cm) = get_course_and_cm_from_cmid($eventdata['contextinstanceid'], 'assign');
+            [$course, $cm] = get_course_and_cm_from_cmid($eventdata['contextinstanceid'], 'assign');
             $assign = $DB->get_record('assign', ['id' => $cm->instance]);
             return $assign;
         }
@@ -759,7 +764,7 @@ function plagiarism_originality_coursemodule_standard_elements($formwrapper, $mf
     if ($config->enabled) {
 
         if ($cmid) {
-            list ($course, $cm) = get_course_and_cm_from_cmid($cmid, 'assign');
+            [$course, $cm] = get_course_and_cm_from_cmid($cmid, 'assign');
             $hassubmissions = $DB->get_records('assign_submission', ['assignment' => $cm->instance]);
 
             if ($hassubmissions) {

--- a/locallib.php
+++ b/locallib.php
@@ -25,6 +25,11 @@
 class plagiarism_plugin_originality_utils {
 
     /**
+     * @var false|mixed|object|string
+     */
+    public $config;
+
+    /**
      * Constructor function for the class.
      * Initializes the configuration settings for the plagiarism_originality plugin.
      *


### PR DESCRIPTION
Added a public utils property to the class plagiarism_plugin_originality in lib.php. Also updated list expressions within if conditions in multiple functions to use shorter bracket notation rather than list function. Similar changes are also made in locallib.php to add a public config property. These changes lead to a more consistent code style in accordance with modern PHP practices.

related to issue26